### PR TITLE
Add support for flan-t5-base in reproduce.sh

### DIFF
--- a/reproduce.sh
+++ b/reproduce.sh
@@ -2,7 +2,7 @@
 
 # Expected command line argument values.
 valid_systems=("ircot" "ircot_qa" "oner" "oner_qa" "nor_qa")
-valid_models=("codex" "flan-t5-xxl" "flan-t5-xl" "flan-t5-large" "flan-t5-base", "none")
+valid_models=("codex" "flan-t5-xxl" "flan-t5-xl" "flan-t5-large" "flan-t5-base" "none")
 valid_datasets=("hotpotqa" "2wikimultihopqa" "musique" "iirc")
 
 # Function to check if an argument is valid

--- a/runner.py
+++ b/runner.py
@@ -7,7 +7,7 @@ import subprocess
 def main():
     parser = argparse.ArgumentParser(description="Wrapper around run.py to make experimentation easier.")
     parser.add_argument("system", type=str, choices=("ircot", "ircot_qa", "nor_qa", "oner", "oner_qa"))
-    parser.add_argument("model", type=str, choices=("codex", "flan-t5-xxl", "flan-t5-xl", "flan-t5-large", "none"))
+    parser.add_argument("model", type=str, choices=("codex", "flan-t5-xxl", "flan-t5-xl", "flan-t5-large", "flan-t5-base", "none"))
     all_datasets = ["hotpotqa", "2wikimultihopqa", "musique", "iirc"]
     all_datasets += ["_to_".join([dataset_a, dataset_b]) for dataset_a in all_datasets for dataset_b in all_datasets]
     parser.add_argument("dataset", type=str, choices=all_datasets)


### PR DESCRIPTION
It isn't possible to select flan-t5-base when wanting to run reproduce.sh. There is an extra comma in the selection array in reproduce.sh and a missing item in the selection array in runner.py
